### PR TITLE
add strip_tags to sanitize

### DIFF
--- a/lib/Meta/Meta.php
+++ b/lib/Meta/Meta.php
@@ -44,9 +44,9 @@ class Meta
     /**
      * Create an HTML Meta tag.
      *
-     * @param string $name    Name of the meta tag
+     * @param string $name Name of the meta tag
      * @param string $content Content of the meta tag
-     * @param string $type    The type of meta tag to generate
+     * @param string $type The type of meta tag to generate
      *
      * @return string Fully formed meta tag
      */
@@ -64,7 +64,7 @@ class Meta
      *
      * @param array $meta Meta information for the givien module
      *
-     * @return string | empty       Meta tag for author property
+     * @return string | empty Meta tag for author property
      */
     private function generateAuthorTag($meta)
     {

--- a/lib/Meta/Meta.php
+++ b/lib/Meta/Meta.php
@@ -44,9 +44,9 @@ class Meta
     /**
      * Create an HTML Meta tag.
      *
-     * @param string $name Name of the meta tag
+     * @param string $name    Name of the meta tag
      * @param string $content Content of the meta tag
-     * @param string $type The type of meta tag to generate
+     * @param string $type    The type of meta tag to generate
      *
      * @return string Fully formed meta tag
      */

--- a/lib/Meta/Meta.php
+++ b/lib/Meta/Meta.php
@@ -22,7 +22,7 @@ class Meta
      */
     protected function sanitize($content)
     {
-        return trim(htmlspecialchars($content));
+        return trim(htmlspecialchars(strip_tags($content)));
     }
 
     /**


### PR DESCRIPTION
Adding this strip_tags to the sanitize function stops html tags from accidentally being passed into the meta tags.